### PR TITLE
Fix: Test paths

### DIFF
--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var chai = require('chai');
-var defineMethod = require('.');
+var defineMethod = require('./');
 
 before(function() {
   chai.should();
@@ -16,7 +16,7 @@ describe('defineMethod(constructor, prop, method)', function() {
   });
 
   it('is the main module', function() {
-    defineMethod.should.equal(require('..'));
+    defineMethod.should.equal(require('../'));
   });
 
   it('adds @method to @constructor', function() {


### PR DESCRIPTION
Prior to Node v4, the path `'.'` must be written as `'./'`
